### PR TITLE
Expose Migrate method

### DIFF
--- a/pkg/dbmigrate/migrate.go
+++ b/pkg/dbmigrate/migrate.go
@@ -62,7 +62,7 @@ func NewLocalMigrator(ctx context.Context, migrateConfig config.Config, migratio
 
 }
 
-// Up will run any un-applied migrations
+// Up looks at the currently active migration version and will migrate all the way up (applying all up migrations).
 func (m *DatabaseMigrator) Up() error {
 	if err := m.wrapped.Up(); err != nil {
 		if errors.Is(err, migrate.ErrNoChange) {
@@ -74,6 +74,19 @@ func (m *DatabaseMigrator) Up() error {
 	return nil
 }
 
+// Migrate looks at the currently active migration version, then migrates either up or down to the specified version.
+func (m *DatabaseMigrator) Migrate(version uint) error {
+	if err := m.wrapped.Migrate(version); err != nil {
+		if errors.Is(err, migrate.ErrNoChange) {
+			m.wrapped.Log.Printf("no changes")
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// Down looks at the currently active migration version and will migrate all the way down (applying all down migrations).
 func (m *DatabaseMigrator) Down() error {
 	if err := m.wrapped.Down(); err != nil {
 		if errors.Is(err, migrate.ErrNoChange) {

--- a/pkg/dbmigrate/migrate_test.go
+++ b/pkg/dbmigrate/migrate_test.go
@@ -109,6 +109,7 @@ func testMigrate(t *testing.T, migrator *dbmigrate.DatabaseMigrator, verificatio
 
 	expectedFunctionName := fmt.Sprintf("%s.update_updated_at_column", schema)
 
+	// function should exist
 	var functionName string
 	require.NoError(t, verificationConn.QueryRow(ctx, fmt.Sprintf(`SELECT to_regproc('%s')`, expectedFunctionName)).Scan(&functionName))
 	assert.NotNil(t, functionName)
@@ -117,6 +118,7 @@ func testMigrate(t *testing.T, migrator *dbmigrate.DatabaseMigrator, verificatio
 	expectedTableName := fmt.Sprintf("%s.test_table", schema)
 	tableExistsQuery := fmt.Sprintf(`SELECT to_regclass('%s')`, expectedTableName)
 
+	// but table should not exist yet
 	var tableName *string
 	require.NoError(t, verificationConn.QueryRow(ctx, tableExistsQuery).Scan(&tableName))
 	assert.Nil(t, tableName)
@@ -124,6 +126,7 @@ func testMigrate(t *testing.T, migrator *dbmigrate.DatabaseMigrator, verificatio
 	// now run all the remaining migrations
 	require.NoError(t, migrator.Up())
 
+	// now table exists
 	require.NoError(t, verificationConn.QueryRow(ctx, tableExistsQuery).Scan(&tableName))
 	require.NotNil(t, tableName)
 	require.Equal(t, expectedTableName, *tableName)

--- a/pkg/dbmigrate/migrate_test.go
+++ b/pkg/dbmigrate/migrate_test.go
@@ -27,6 +27,7 @@ func TestDatabaseMigrator(t *testing.T) {
 		tstFunc  func(t *testing.T, migrator *dbmigrate.DatabaseMigrator, verificationConn *pgx.Conn)
 	}{
 		{"test Up", testUp},
+		{"test Migrate", testMigrate},
 		{"Up and Down run without error", testUpAndDown},
 	}
 
@@ -98,6 +99,35 @@ func testUp(t *testing.T, migrator *dbmigrate.DatabaseMigrator, verificationConn
 	)
 	assert.False(t, updatedUpdatedAt.IsZero())
 	assert.False(t, updatedAt.Equal(updatedUpdatedAt))
+}
+
+func testMigrate(t *testing.T, migrator *dbmigrate.DatabaseMigrator, verificationConn *pgx.Conn) {
+	ctx := context.Background()
+
+	// Only run the first migration
+	require.NoError(t, migrator.Migrate(20250319124829))
+
+	expectedFunctionName := fmt.Sprintf("%s.update_updated_at_column", schema)
+
+	var functionName string
+	require.NoError(t, verificationConn.QueryRow(ctx, fmt.Sprintf(`SELECT to_regproc('%s')`, expectedFunctionName)).Scan(&functionName))
+	assert.NotNil(t, functionName)
+	assert.Equal(t, expectedFunctionName, functionName)
+
+	expectedTableName := fmt.Sprintf("%s.test_table", schema)
+	tableExistsQuery := fmt.Sprintf(`SELECT to_regclass('%s')`, expectedTableName)
+
+	var tableName *string
+	require.NoError(t, verificationConn.QueryRow(ctx, tableExistsQuery).Scan(&tableName))
+	assert.Nil(t, tableName)
+
+	// now run all the remaining migrations
+	require.NoError(t, migrator.Up())
+
+	require.NoError(t, verificationConn.QueryRow(ctx, tableExistsQuery).Scan(&tableName))
+	require.NotNil(t, tableName)
+	require.Equal(t, expectedTableName, *tableName)
+
 }
 
 // We don't really use the Down() method for real. Test is here so that


### PR DESCRIPTION
PR exposes the golang-migrate `Migrate.Migrate(version)` method in our `DatabaseMigrator` so that users can migration up or down to a specific migration.